### PR TITLE
[CICD] Run linter on main

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,8 +6,6 @@ concurrency:
 
 on:
   push:
-    branches-ignore:
-      - main
   workflow_call:
 
 permissions:


### PR DESCRIPTION
## Summary

This will speed up lint runs by storing a shared cache. Can also find errors caused by merge issues.

## How was it tested?
CICD

## Is this change backwards-compatible?
yes