### PR TITLE
Add triggers to update launchpad version in axiom

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,31 @@
+name: release
+
+on:
+  # Build/Release on demand
+  workflow_dispatch:
+  push:
+    tags:
+      - "*" # Tags that trigger a new release version
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yaml
+
+  release:
+    runs-on: ubuntu-latest
+    environment: release
+    needs: tests
+    # Only release when there's a tag for the release.
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Update axiom
+        run: |
+          curl -X POST ${{ secrets.AXIOM_WEBHOOK_URL }} \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.AXIOM_WEBHOOK_SECRET }}" \
+            -d '{"event_type":"update-launchpad-version", "client_payload": {"version":"${{github.ref_name}}"}}'
+ 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-
 # Launchpad
 
-Launchpad provides the best developer experience for deploying any application to Kubernetes. Skip writing pages of Kubernetes YAML, and deploy in seconds with Launchpad's minimal deployment config.
+Deploy any application to Kubernetes with Launchpad. Skip writing pages of Kubernetes YAML, and deploy in seconds with Launchpad's minimal deployment config.
 
 ### Build and deploy with a single command
 
@@ -9,7 +8,7 @@ Launchpad up can build any image, push to your Docker registry, and generate Hel
 
 ## Get started
 
-https://www.jetpack.io/docs/
+https://www.jetpack.io/launchpad/docs/
 
 ## Build from source
 


### PR DESCRIPTION
## Summary
- Update code: `git co main` and `git pull`
- Tag commit:`git tag -a 0.0.10`
    - Write a brief message in the “pop up message screen”: `devbox 0.0.10`
    - `git log -n1` should show `HEAD` has this tag `0.0.1`
- Push to Github: `git push origin 0.0.10`
- This should trigger the `release` github workflow, which calls the axiom webhook to update launchpad oss version

## How was it tested?
cicd?

## Is this change backwards-compatible?
Yes