### PR TITLE
Remove authentication requirement for launchpad init

### DIFF
--- a/padcli/command/config.go
+++ b/padcli/command/config.go
@@ -28,15 +28,11 @@ func configCmd() *cobra.Command {
 		Long: "upgrades a project's launchpad.yaml to follow the latest schema found " +
 			"at https://www.jetpack.io/launchpad/docs/reference/launchpad.yaml-reference/",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, err := cmdOpts.AuthProvider().Identify(cmd.Context())
-			if err != nil {
-				return errors.WithStack(err)
-			}
-
+			ctx := cmd.Context()
 			jetlog.Logger(ctx).HeaderPrintf("Step 1/1 checking if the jetconfig needs to upgrade.\n")
 
 			// This calls upgrade internally.
-			_, err = RequireConfigFromFileSystem(ctx, cmd, args)
+			_, err := RequireConfigFromFileSystem(ctx, cmd, args)
 			if err != nil {
 				return errors.WithStack(err)
 			}
@@ -94,7 +90,8 @@ func loadOrInitConfigFromFileSystem(
 		"Running `launchpad init <app-directory>`\n", configFileName, p)
 	jetlog.Logger(ctx).Println(
 		"Setting up your launchpad application. Press `ctrl-c` to exit")
-	if err := initConfig(ctx, p); err != nil {
+
+	if err := initConfig(ctx, cmdOpts.AuthProvider(), p); err != nil {
 		return nil, errors.WithStack(err)
 	}
 	c, err = RequireConfigFromFileSystem(ctx, cmd, cmdArgs)

--- a/padcli/command/initcmd.go
+++ b/padcli/command/initcmd.go
@@ -173,6 +173,8 @@ func runConfigSurvey(
 	}
 	// In case user wants to log in and use a jetpack managed cluster.
 	clusterNames = append(clusterNames, jetpackManagedCluster)
+	// In case user wants to create a cluster.
+	clusterNames = append(clusterNames, createJetpackCluster)
 
 	qs, err := surveyQuestions(ctx, appName, clusterNames)
 	if err != nil {

--- a/padcli/command/initcmd.go
+++ b/padcli/command/initcmd.go
@@ -209,17 +209,17 @@ func runConfigSurvey(
 		}
 
 		// Only show the jetpack managed cluster names.
-		clusterNames := []string{createJetpackCluster}
+		clusterNames := []string{}
 		for _, c := range clusters {
 			if c.IsJetpackManaged() {
 				clusterNames = append(clusterNames, c.GetName())
 			}
 		}
-
-		// If no jetpack managed cluster exist, we default the answer to the only option available.
-		if len(clusterNames) == 1 {
-			answers.ClusterOption = clusterNames[0]
+		if len(clusterNames) == 0 {
+			answers.ClusterOption = createJetpackCluster
 		} else {
+			// Add option to select creating a new managed cluster.
+			clusterNames = append(clusterNames, createJetpackCluster)
 			additionalClusterSurvey := surveyJetpackManagedClusterQuestions(ctx, clusterNames)
 			err = survey.Ask([]*survey.Question{additionalClusterSurvey["ClusterOption"]}, &answers.ClusterOption)
 			if err != nil {

--- a/padcli/command/initcmd.go
+++ b/padcli/command/initcmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.jetpack.io/launchpad/goutil/errorutil"
 	"go.jetpack.io/launchpad/padcli/jetconfig"
+	"go.jetpack.io/launchpad/padcli/provider"
 	"go.jetpack.io/launchpad/pkg/jetlog"
 	"go.jetpack.io/launchpad/pkg/kubevalidate"
 )
@@ -18,8 +19,10 @@ import (
 type serviceTypeOption string
 
 const (
-	webServiceType     serviceTypeOption = "Web Service"
-	cronjobServiceType serviceTypeOption = "Cron Job"
+	webServiceType        serviceTypeOption = "Web Service"
+	cronjobServiceType    serviceTypeOption = "Cron Job"
+	jetpackManagedCluster string            = "Jetpack managed cluster"
+	createJetpackCluster  string            = "Create a new cluster with Jetpack"
 )
 
 type SurveyAnswers struct {
@@ -36,16 +39,13 @@ func initCmd() *cobra.Command {
 		Short: "init a new Launchpad config",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, err := cmdOpts.AuthProvider().Identify(cmd.Context())
-			if err != nil {
-				return errors.WithStack(err)
-			}
+			authProvider := cmdOpts.AuthProvider()
 			path, err := absPath(args)
 			if err != nil {
 				return errors.WithStack(err)
 			}
 
-			return initConfig(ctx, path)
+			return initConfig(cmd.Context(), authProvider, path)
 		},
 	}
 
@@ -85,7 +85,7 @@ func projectDir(args []string) (string, error) {
 	return dir, nil
 }
 
-func initConfig(ctx context.Context, path string) error {
+func initConfig(ctx context.Context, authProvider provider.Auth, path string) error {
 	appName, err := appName(path)
 	if err != nil {
 		return errors.WithStack(err)
@@ -102,11 +102,17 @@ func initConfig(ctx context.Context, path string) error {
 		return errors.WithStack(err)
 	}
 
-	answers, err := runConfigSurvey(ctx, appName)
+	answers, err := runConfigSurvey(ctx, authProvider, appName)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	if answers == nil {
+		return nil
+	}
+
+	if answers.ClusterOption == createJetpackCluster {
+		// Ask users to create a cluster first.
+		jetlog.Logger(ctx).Printf("\nTo create a new cluster, run `launchpad cluster create <cluster_name>`.\n")
 		return nil
 	}
 
@@ -126,7 +132,7 @@ func initConfig(ctx context.Context, path string) error {
 		)
 	}
 
-	if answers.ClusterOption != "" {
+	if answers.ClusterOption != "" && answers.ClusterOption != createJetpackCluster {
 		jetCfg.Cluster = answers.ClusterOption
 	}
 	if answers.ImageRepositoryLocation != "" {
@@ -146,11 +152,13 @@ func initConfig(ctx context.Context, path string) error {
 			"https://www.jetpack.io/launchpad/docs/reference/launchpad.yaml-reference/ \n",
 		configPath,
 	)
+
 	return nil
 }
 
 func runConfigSurvey(
 	ctx context.Context,
+	authProvider provider.Auth,
 	appName string,
 ) (*SurveyAnswers, error) {
 
@@ -158,16 +166,14 @@ func runConfigSurvey(
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	if len(clusters) == 0 {
-		// No clusters available. Show user-friendly error.
-		return nil, errorutil.NewUserError("We were unable to find a kubernetes cluster in your kubeconfig, " +
-			"which is required to use Launchpad. You can set one up with Docker or use Launchpad to create one for you")
-	}
 
 	clusterNames := []string{}
 	for _, c := range clusters {
 		clusterNames = append(clusterNames, c.GetName())
 	}
+	// In case user wants to log in and use a jetpack managed cluster.
+	clusterNames = append(clusterNames, jetpackManagedCluster)
+
 	qs, err := surveyQuestions(ctx, appName, clusterNames)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -188,6 +194,38 @@ func runConfigSurvey(
 	err = survey.Ask([]*survey.Question{qs["ClusterOption"]}, &answers.ClusterOption)
 	if err != nil {
 		return nil, errors.WithStack(err)
+	}
+
+	if answers.ClusterOption == jetpackManagedCluster {
+		// Prompt users to log in.
+		ctx, err := authProvider.Identify(ctx)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		// Get all the cluster names again.
+		clusters, err := cmdOpts.ClusterProvider().GetAll(ctx)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		// Only show the jetpack managed cluster names.
+		clusterNames := []string{createJetpackCluster}
+		for _, c := range clusters {
+			if c.IsJetpackManaged() {
+				clusterNames = append(clusterNames, c.GetName())
+			}
+		}
+
+		// If no jetpack managed cluster exist, we default the answer to the only option available.
+		if len(clusterNames) == 1 {
+			answers.ClusterOption = clusterNames[0]
+		} else {
+			additionalClusterSurvey := surveyJetpackManagedClusterQuestions(ctx, clusterNames)
+			err = survey.Ask([]*survey.Question{additionalClusterSurvey["ClusterOption"]}, &answers.ClusterOption)
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+		}
 	}
 
 	return answers, nil
@@ -240,7 +278,7 @@ func surveyQuestions(ctx context.Context, appName string, clusterNames []string)
 			},
 		},
 		"ClusterOption": {
-			Name: "UseJetpackTrialCluster",
+			Name: "ClusterOption",
 			Prompt: &survey.Select{
 				Message: "To which cluster do you want to deploy this project?",
 				Options: clusterNames,
@@ -256,6 +294,18 @@ func surveyQuestions(ctx context.Context, appName string, clusterNames []string)
 	}
 
 	return questions, nil
+}
+
+func surveyJetpackManagedClusterQuestions(ctx context.Context, clusterNames []string) map[string]*survey.Question {
+	return map[string]*survey.Question{
+		"ClusterOption": {
+			Name: "ClusterOption",
+			Prompt: &survey.Select{
+				Message: "To which jetpack managed cluster do you want to deploy this project?",
+				Options: clusterNames,
+			},
+		},
+	}
 }
 
 func appName(path string) (string, error) {


### PR DESCRIPTION
## Summary
This is the first step towards removing auth requirement for most commands, starting with init.
<img width="755" alt="Screen Shot 2022-11-03 at 11 53 19 AM" src="https://user-images.githubusercontent.com/2292093/199810229-ed4ca1ff-fa8c-41a9-876a-14cc716107b5.png">

<img width="890" alt="Screen Shot 2022-11-03 at 11 47 37 AM" src="https://user-images.githubusercontent.com/2292093/199810253-5bcc406c-388b-468f-8de9-8825ce1c558c.png">

<img width="893" alt="Screen Shot 2022-11-03 at 11 48 08 AM" src="https://user-images.githubusercontent.com/2292093/199810298-1e7fab95-e4bf-47ad-bd7d-476c3c6b4182.png">


## How was it tested?
cli-build
launchpad logout
launchpad init

## Is this change backwards-compatible?
Yes