### PR TITLE
fix helm download for runtime chart DEV-1228

### DIFF
--- a/launchpad/helm.go
+++ b/launchpad/helm.go
@@ -233,7 +233,7 @@ func getChart(
 	cp, err := cpo.LocateChart(chartURL, settings)
 
 	buildstmp := buildstamp.Get()
-	if err != nil && strings.Contains(err.Error(), "failed to download") && buildstmp.IsDevBinary() {
+	if err != nil && strings.Contains(err.Error(), "failed to fetch") && buildstmp.IsDevBinary() {
 		// This can happen in development because referenced version is dirty and
 		// the helm chart has not been released. In this case, we use the latest chart version.
 		cp, err = getLatestChart(cc, settings, cpo)


### PR DESCRIPTION
## Summary
This is breaking `launchpad up` when building locally. I'd really like to get rid of this entirely.

## How was it tested?
cli-build.sh
launchpad up

## Is this change backwards-compatible?
yes