### PR TITLE
Add envsec provider field in jetconfig DEV-1229

### DIFF
--- a/padcli/command/common.go
+++ b/padcli/command/common.go
@@ -36,6 +36,10 @@ func getRemoteEnvVars(
 	store envsec.Store,
 ) (map[string]string, error) {
 
+	envVars := map[string]string{}
+	if store == nil {
+		return envVars, nil
+	}
 	// load secrets from parameter store
 	envID, err := cmdOpts.EnvSecProvider().NewEnvId(ctx, jetCfg.GetProjectID(), cmdOpts.RootFlags().Env().String())
 	if err != nil {
@@ -46,7 +50,6 @@ func getRemoteEnvVars(
 		return nil, errors.WithStack(err)
 	}
 
-	envVars := map[string]string{}
 	for _, envVar := range storeEnvVars {
 		envVars[envVar.Name] = envVar.Value
 	}

--- a/padcli/command/dev.go
+++ b/padcli/command/dev.go
@@ -165,7 +165,7 @@ func autoDeploy(
 			return errors.WithStack(err)
 		}
 
-		store, err := newEnvStore(ctx, cmdOpts.EnvSecProvider())
+		store, err := newEnvStore(ctx, cmd, cmdArgs, cmdOpts.EnvSecProvider())
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/padcli/command/env.go
+++ b/padcli/command/env.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -13,6 +12,7 @@ import (
 	"go.jetpack.io/envsec/envcli"
 	"go.jetpack.io/launchpad/padcli/jetconfig"
 	"go.jetpack.io/launchpad/padcli/provider"
+	"go.jetpack.io/launchpad/pkg/jetlog"
 )
 
 type envOptions struct {
@@ -163,13 +163,13 @@ func newEnvStore(
 		return nil, errors.WithStack(err)
 	}
 
-	if jetCfg.Envsec.Provider != jetconfig.DefaultEnvsecProvider {
-		jetCfg.Envsec.Provider = jetconfig.DefaultEnvsecProvider
+	if jetCfg.Envsec.Provider != jetconfig.JetpackEnvsecProvider {
+		jetCfg.Envsec.Provider = jetconfig.JetpackEnvsecProvider
 		_, err = jetCfg.SaveConfig(path)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
-		fmt.Println("We have updated your project's launchpad.yaml. Please commit that to your repository.")
+		jetlog.Logger(ctx).Println("We have updated your project's launchpad.yaml. Please commit that to your repository.")
 	}
 
 	return store, nil

--- a/padcli/command/local.go
+++ b/padcli/command/local.go
@@ -73,7 +73,7 @@ func localCmd() *cobra.Command {
 				}
 			}
 
-			store, err := newEnvStore(ctx, cmdOpts.EnvSecProvider())
+			store, err := newEnvStore(ctx, cmd, args, cmdOpts.EnvSecProvider())
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/padcli/command/up.go
+++ b/padcli/command/up.go
@@ -89,7 +89,7 @@ func upCmd() *cobra.Command {
 				return errors.WithStack(err)
 			}
 
-			store, err := newEnvStore(ctx, cmdOpts.EnvSecProvider())
+			store, err := newEnvStore(ctx, cmd, args, cmdOpts.EnvSecProvider())
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/padcli/jetconfig/jetconfig.go
+++ b/padcli/jetconfig/jetconfig.go
@@ -16,7 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const DefaultEnvsecProvider = "jetpack"
+const JetpackEnvsecProvider = "jetpack"
 const defaultFileName = "launchpad.yaml"
 
 type EnvironmentFields struct {

--- a/padcli/jetconfig/jetconfig.go
+++ b/padcli/jetconfig/jetconfig.go
@@ -16,11 +16,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const DefaultEnvsecProvider = "jetpack"
 const defaultFileName = "launchpad.yaml"
 
 type EnvironmentFields struct {
 	// Default flags
 	Flags FlagSet `yaml:"flags,omitempty"`
+}
+
+type EnvsecFields struct {
+	Provider string `yaml:"provider,omitempty"`
 }
 
 // TODO, make this struct unexported
@@ -36,6 +41,8 @@ type Config struct {
 	// The cluster to deploy to. Should be the unique name of a Jetpack-managed cluster,
 	// or the name of a context in the user's kubeconfig.
 	Cluster string `yaml:"cluster,omitempty"` // --cluster
+
+	Envsec EnvsecFields `yaml:"envsec,omitempty"`
 
 	ImageRepository string `yaml:"imageRepository,omitempty"`
 


### PR DESCRIPTION
## Summary
Upon invoking `launchpad env` for the first time, `envsec` field will be inserted in `launchpad.yaml`

<img width="423" alt="Screen Shot 2022-11-07 at 11 05 06 AM" src="https://user-images.githubusercontent.com/2292093/200393476-5cfea0d4-32d2-4484-9474-07fe86702d3a.png">


## How was it tested?
`launchpad env ls`

## Is this change backwards-compatible?
Yes