### PR TITLE
Read whether a cluster is Jetpack-managed or not from the kubeconfig

### DIFF
--- a/padcli/kubeconfig/kubeconfig.go
+++ b/padcli/kubeconfig/kubeconfig.go
@@ -166,6 +166,19 @@ func GetContextNames() ([]string, error) {
 	return names, nil
 }
 
+func GetAuthInfo(authInfoName string) (*api.AuthInfo, error) {
+	rawCfg, err := getRawKubeConfig()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if info, ok := rawCfg.AuthInfos[authInfoName]; ok {
+		return info, nil
+	} else {
+		return nil, errors.Errorf("no AuthInfo found with name %s", authInfoName)
+	}
+}
+
 func GetServer(context string) (string, error) {
 	rawCfg, err := getRawKubeConfig()
 	if err != nil {

--- a/padcli/provider/cluster.go
+++ b/padcli/provider/cluster.go
@@ -67,7 +67,7 @@ func (c *kubeConfigCluster) IsLocal() bool {
 }
 
 func (c *kubeConfigCluster) IsRemoteUnmanaged() bool {
-	return !c.local
+	return !c.local && !c.jetpackManaged
 }
 
 func (c *kubeConfigCluster) GetIsPrivate() bool {


### PR DESCRIPTION
## Summary

Determine whether a cluster in a kubeconfig is Jetpack-managed or not by reading its `exec` command in the kubeconfig. This is just a good enough/temporary solution. In the future, we should be writing this information somewhere or exposing some API that can provide this information.

## How was it tested?
Tested by printing out some extra information in `launchpad init` and ran it against my existing kubeconfig
<img width="648" alt="Screen Shot 2022-11-07 at 5 30 04 PM" src="https://user-images.githubusercontent.com/1203781/200429330-1c76d2a0-7c01-4c2c-84bb-3629a55f0647.png">


## Is this change backwards-compatible?
Yes