### PR TITLE
Do not deploy runtime chart if runtime is not needed DEV-1225

### DIFF
--- a/launchpad/deploy.go
+++ b/launchpad/deploy.go
@@ -323,14 +323,12 @@ func (p *Pad) makeDeployPlan(
 		return err == nil && isInstalled
 	}
 
-	// Optimization: skip jetpack-runtime if we can.
-	installRuntime, _ := appValues["jetpack"].(map[string]any)["runSDKRegister"].(bool)
-	if installRuntime && runtimeIsCurrent() {
+	if runtimeIsCurrent() {
 		jetlog.Logger(ctx).IndentedPrintf(
 			"\nSkipping upgrade of %s because there are no changes\n",
 			runtimeChartConfig.Release,
 		)
-	} else if installRuntime {
+	} else {
 		secretData, err := GetRuntimeSecretData(ctx, opts.KubeContext, opts.Namespace)
 		if err != nil {
 			return nil, errors.WithStack(err)

--- a/padcli/command/deploy.go
+++ b/padcli/command/deploy.go
@@ -92,6 +92,8 @@ func makeDeployOptions(
 	if err != nil {
 		return nil, err
 	}
+
+	var runtimeHelm *launchpad.HelmOptions
 	runtimeValues, err := cmdOpts.Hooks().PostRuntimeChartValuesCompute(
 		ctx,
 		cmdOpts,
@@ -99,6 +101,22 @@ func makeDeployOptions(
 	)
 	if err != nil {
 		return nil, err
+	}
+	runtimeValues, err = helm.MergeValues(
+		runtimeValues,
+		[]string{}, // values files
+		opts.Runtime.SetValues,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed merging --helm.runtime.set values")
+	}
+	if len(runtimeValues) != 0 {
+		runtimeHelm = &launchpad.HelmOptions{
+			ChartLocation: opts.Runtime.ChartLocation,
+			Values:        runtimeValues,
+			// Not ideal, but better than failing. We need to fine tune.
+			Timeout: 5 * time.Minute,
+		}
 	}
 
 	// if --env-override flag was explicitly set, then add values to helmOptions
@@ -116,15 +134,6 @@ func makeDeployOptions(
 
 	if cmd.Flags().Changed(mountSecretFileFlag) && cmd.Flags().Changed(mountSecretFilesFlag) {
 		return nil, errors.Errorf("Incompatible command line opts '%v' and '%v' : Prefer specifying a list of secret files using '%v'", mountSecretFileFlag, mountSecretFilesFlag, mountSecretFilesFlag)
-	}
-
-	runtimeValues, err = helm.MergeValues(
-		runtimeValues,
-		[]string{}, // values files
-		opts.Runtime.SetValues,
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed merging --helm.runtime.set values")
 	}
 
 	appValues["secrets"] = appSecrets
@@ -153,20 +162,15 @@ func makeDeployOptions(
 			Values:        appValues,
 			Timeout:       lo.Ternary(len(jetCfg.Jobs()) > 0, 5*time.Minute, 0),
 		},
-		Environment:    cmdOpts.RootFlags().Env().String(),
-		ExternalCharts: jetconfigHelmToChartConfig(jetCfg, ns),
-		JetCfg:         jetCfg,
-		IsLocalCluster: cluster.IsLocal(),
-		KubeContext:    cluster.GetKubeContext(),
-		LifecycleHook:  cmdOpts.Hooks().Deploy,
-		Namespace:      ns,
-		RemoteEnvVars:  remoteEnvVars,
-		Runtime: &launchpad.HelmOptions{
-			ChartLocation: opts.Runtime.ChartLocation,
-			Values:        runtimeValues,
-			// Not ideal, but better than failing. We need to fine tune.
-			Timeout: 5 * time.Minute,
-		},
+		Environment:                 cmdOpts.RootFlags().Env().String(),
+		ExternalCharts:              jetconfigHelmToChartConfig(jetCfg, ns),
+		JetCfg:                      jetCfg,
+		IsLocalCluster:              cluster.IsLocal(),
+		KubeContext:                 cluster.GetKubeContext(),
+		LifecycleHook:               cmdOpts.Hooks().Deploy,
+		Namespace:                   ns,
+		RemoteEnvVars:               remoteEnvVars,
+		Runtime:                     runtimeHelm,
 		SecretFilePaths:             opts.SecretFilePaths,
 		ReinstallOnHelmUpgradeError: opts.ReinstallOnHelmUpgradeError,
 	}, nil

--- a/padcli/command/deploy.go
+++ b/padcli/command/deploy.go
@@ -93,7 +93,6 @@ func makeDeployOptions(
 		return nil, err
 	}
 
-	var runtimeHelm *launchpad.HelmOptions
 	runtimeValues, err := cmdOpts.Hooks().PostRuntimeChartValuesCompute(
 		ctx,
 		cmdOpts,
@@ -110,6 +109,8 @@ func makeDeployOptions(
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed merging --helm.runtime.set values")
 	}
+
+	var runtimeHelm *launchpad.HelmOptions
 	if len(runtimeValues) != 0 {
 		runtimeHelm = &launchpad.HelmOptions{
 			ChartLocation: opts.Runtime.ChartLocation,


### PR DESCRIPTION
## Summary
If runtime is not needed, do not deploy runtime helm chart

## How was it tested?
launchpad up

## Is this change backwards-compatible?
Yes