### PR TITLE
[cluster] Add selected cluster to cluster provider interface

### DIFF
--- a/padcli/command/build.go
+++ b/padcli/command/build.go
@@ -27,7 +27,6 @@ type embeddedBuildOptions struct {
 	BuildArgs   map[string]string
 	LocalImage  string
 	RemoteCache bool
-	jflags.Common
 }
 
 type buildOptions struct {
@@ -59,7 +58,7 @@ func buildCmd() *cobra.Command {
 			}
 
 			// Only needed because of --remote-cache:
-			cluster, err := cmdOpts.ClusterProvider().Get(ctx, opts.DefaultedCluster(jetCfg))
+			cluster, err := cmdOpts.ClusterProvider().Get(ctx)
 			if err != nil {
 				return errors.WithStack(err)
 			}
@@ -95,7 +94,7 @@ func buildCmd() *cobra.Command {
 // registerBuildFlags is only called by the build command. One call site.
 func registerBuildFlags(cmd *cobra.Command, opts *buildOptions) {
 	registerEmbeddedBuildFlags(cmd, &opts.embeddedBuildOptions)
-	jflags.RegisterCommonFlags(cmd, &opts.Common)
+	jflags.RegisterCommonFlags(cmd, cmdOpts)
 }
 
 // registerEmbeddedBuildFlags is called by many commands: up, dev, build, local.

--- a/padcli/command/dev.go
+++ b/padcli/command/dev.go
@@ -27,7 +27,6 @@ import (
 type devOptions struct {
 	deployOptions
 	embeddedBuildOptions
-	jflags.Common
 	publishOptions
 }
 
@@ -87,7 +86,7 @@ func devCmd() *cobra.Command {
 }
 
 func registerDevFlags(cmd *cobra.Command, opts *devOptions) {
-	jflags.RegisterCommonFlags(cmd, &opts.Common)
+	jflags.RegisterCommonFlags(cmd, cmdOpts)
 	registerDeployFlags(cmd, &opts.deployOptions)
 	registerEmbeddedBuildFlags(cmd, &opts.embeddedBuildOptions)
 	registerPublishFlags(cmd, &opts.publishOptions)
@@ -141,7 +140,7 @@ func autoDeploy(
 		}
 
 		// If the selected cluster is a Jetpack-managed cluster, use its public hostname.
-		cluster, err := cmdOpts.ClusterProvider().Get(ctx, opts.DefaultedCluster(jetCfg))
+		cluster, err := cmdOpts.ClusterProvider().Get(ctx)
 		if err != nil {
 			logsAndPortFwdCancelFn()
 			return errors.WithStack(err)

--- a/padcli/command/down.go
+++ b/padcli/command/down.go
@@ -30,7 +30,7 @@ func downCmd() *cobra.Command {
 				return errors.WithStack(err)
 			}
 
-			c, err := RequireConfigFromFileSystem(ctx, cmd, args)
+			c, err := RequireConfigFromFileSystem(ctx, cmd, args, cmdOpts)
 			if errors.Is(err, jetconfig.ErrConfigNotFound) {
 				return errorutil.NewUserError(
 					"jetconfig not found. Please run `launchpad down` in launchpad project " +
@@ -65,7 +65,7 @@ func downCmd() *cobra.Command {
 		},
 	}
 
-	jflags.RegisterDownFlags(downCmd, flags)
+	jflags.RegisterDownFlags(downCmd, flags, cmdOpts)
 	return downCmd
 }
 
@@ -74,7 +74,7 @@ func makeLaunchpadDownOptions(
 	jetCfg *jetconfig.Config,
 	flags *jflags.DownCmd,
 ) (*launchpad.DownOptions, error) {
-	cluster, err := cmdOpts.ClusterProvider().Get(ctx, flags.DefaultedCluster(jetCfg))
+	cluster, err := cmdOpts.ClusterProvider().Get(ctx)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/padcli/command/env.go
+++ b/padcli/command/env.go
@@ -48,7 +48,7 @@ func envCmd() *cobra.Command {
 				return errors.WithStack(err)
 			}
 
-			c, err := RequireConfigFromFileSystem(ctx, cmd, []string{absProjectPath})
+			c, err := RequireConfigFromFileSystem(ctx, cmd, []string{absProjectPath}, cmdOpts)
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/padcli/command/jflags/common.go
+++ b/padcli/command/jflags/common.go
@@ -2,27 +2,15 @@ package jflags
 
 import (
 	"github.com/spf13/cobra"
-	"go.jetpack.io/launchpad/goutil"
+	"go.jetpack.io/launchpad/padcli/provider"
 )
 
-func RegisterCommonFlags(cmd *cobra.Command, flags *Common) {
+func RegisterCommonFlags(cmd *cobra.Command, p provider.Providers) {
 	cmd.Flags().StringVarP(
-		&flags.cluster,
+		p.ClusterProvider().GetSelectedClusterName(),
 		"cluster",
 		"c",
 		"",
 		"The Kubernetes cluster to deploy to. Can be the name of Jetpack-managed cluster or the name of a context in your kubeconfig",
 	)
-}
-
-type Common struct {
-	cluster string
-}
-
-type clusterProvider interface {
-	GetCluster() string
-}
-
-func (c *Common) DefaultedCluster(p clusterProvider) string {
-	return goutil.Coalesce(c.cluster, p.GetCluster())
 }

--- a/padcli/command/jflags/down.go
+++ b/padcli/command/jflags/down.go
@@ -2,13 +2,14 @@ package jflags
 
 import (
 	"github.com/spf13/cobra"
+	"go.jetpack.io/launchpad/padcli/provider"
 )
 
 func NewDownCmd() *DownCmd {
 	return &DownCmd{}
 }
 
-func RegisterDownFlags(cmd *cobra.Command, flags *DownCmd) {
+func RegisterDownFlags(cmd *cobra.Command, flags *DownCmd, p provider.Providers) {
 	cmd.Flags().StringVarP(
 		&flags.namespace,
 		"namespace",
@@ -22,12 +23,10 @@ func RegisterDownFlags(cmd *cobra.Command, flags *DownCmd) {
 		"",
 		"App install name",
 	)
-	RegisterCommonFlags(cmd, &flags.Common)
+	RegisterCommonFlags(cmd, p)
 }
 
 type DownCmd struct {
-	Common
-
 	app       string
 	namespace string
 }

--- a/padcli/command/local.go
+++ b/padcli/command/local.go
@@ -44,7 +44,7 @@ func localCmd() *cobra.Command {
 			jetlog.Logger(ctx).Printf("Launchpad is preparing to build %s.\n", jetCfg.GetProjectName())
 
 			// Only needed because of --remote-cache:
-			cluster, err := cmdOpts.ClusterProvider().Get(ctx, opts.DefaultedCluster(jetCfg))
+			cluster, err := cmdOpts.ClusterProvider().Get(ctx)
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/padcli/command/mock/cmdopts.go
+++ b/padcli/command/mock/cmdopts.go
@@ -109,7 +109,6 @@ func (*mockUser) Email() string {
 
 func (*mockClusterProvider) Get(
 	ctx context.Context,
-	kubeContextName string,
 ) (provider.Cluster, error) {
 	return NewClusterForTest("local", true), nil
 }
@@ -123,6 +122,12 @@ func (*mockClusterProvider) GetAll(
 		NewJetpackManagedClusterForTest("remote-not-jetpack", "byoc-cluster"),
 	}, nil
 }
+
+func (p *mockClusterProvider) GetSelectedClusterName() *string {
+	return nil
+}
+
+func (p *mockClusterProvider) SetSelectedClusterName(name string) {}
 
 func (*mockNamespaceProvider) Get(
 	ctx context.Context,

--- a/padcli/command/up.go
+++ b/padcli/command/up.go
@@ -46,7 +46,6 @@ type publishOptions struct {
 }
 
 type upOptions struct {
-	jflags.Common
 	deployOptions
 	embeddedBuildOptions
 	publishOptions
@@ -79,7 +78,7 @@ func upCmd() *cobra.Command {
 				return errors.WithStack(err)
 			}
 
-			cluster, err := cmdOpts.ClusterProvider().Get(ctx, opts.DefaultedCluster(jetCfg))
+			cluster, err := cmdOpts.ClusterProvider().Get(ctx)
 			if err != nil {
 				return errors.WithStack(err)
 			}
@@ -144,7 +143,7 @@ func upCmd() *cobra.Command {
 }
 
 func registerUpFlags(cmd *cobra.Command, opts *upOptions) {
-	jflags.RegisterCommonFlags(cmd, &opts.Common)
+	jflags.RegisterCommonFlags(cmd, cmdOpts)
 	registerDeployFlags(cmd, &opts.deployOptions)
 	registerEmbeddedBuildFlags(cmd, &opts.embeddedBuildOptions)
 	registerPublishFlags(cmd, &opts.publishOptions)

--- a/padcli/command/up_test.go
+++ b/padcli/command/up_test.go
@@ -88,7 +88,7 @@ func (t *Suite) TestBuildPublishAndDeploy() {
 	req.NoError(err)
 
 	cmdOpts.RootFlags().Environment = "dev"
-	jetCfg, err = RequireConfigFromFileSystem(ctx, cmd, []string{configPath})
+	jetCfg, err = RequireConfigFromFileSystem(ctx, cmd, []string{configPath}, cmdOpts)
 	req.NoError(err)
 
 	// Copy the files under testdata to the temp directory


### PR DESCRIPTION
## Summary

This simplifies the cluster provider interface by removing the need to pass a cluster name every time we call `Get()`. This uses state in the provider which is associated to the cluster flag and also set when the jetconfig is read. 

## How was it tested?

* Compiles/tests
* launchpad up (on commercial version) (with jetconfig cluster and also using `--cluster` flag)

## Is this change backwards-compatible?
yes
