### PR TITLE
[init] Add init survey provider

### DIFF
--- a/padcli/command/build.go
+++ b/padcli/command/build.go
@@ -17,11 +17,6 @@ const (
 	localImageFlag = "local-image"
 )
 
-const (
-	imageRepositoryFlagHelpMsg = "Image repository to push the built image to. " +
-		"Your kubernetes cluster must have the permissions to pull images from this repository."
-)
-
 type embeddedBuildOptions struct {
 	Platform    string
 	BuildArgs   map[string]string

--- a/padcli/command/initcmd.go
+++ b/padcli/command/initcmd.go
@@ -2,11 +2,9 @@ package command
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/launchpad/goutil/errorutil"
@@ -15,23 +13,6 @@ import (
 	"go.jetpack.io/launchpad/pkg/jetlog"
 	"go.jetpack.io/launchpad/pkg/kubevalidate"
 )
-
-type serviceTypeOption string
-
-const (
-	webServiceType        serviceTypeOption = "Web Service"
-	cronjobServiceType    serviceTypeOption = "Cron Job"
-	jetpackManagedCluster string            = "Jetpack managed cluster"
-	createJetpackCluster  string            = "Create a new cluster with Jetpack"
-)
-
-type SurveyAnswers struct {
-	AppName                 string
-	AppType                 string
-	ClusterOption           string
-	KubeContext             string
-	ImageRepositoryLocation string
-}
 
 func initCmd() *cobra.Command {
 	var initCmd = &cobra.Command{
@@ -44,7 +25,6 @@ func initCmd() *cobra.Command {
 			if err != nil {
 				return errors.WithStack(err)
 			}
-
 			return initConfig(cmd.Context(), authProvider, path)
 		},
 	}
@@ -102,7 +82,7 @@ func initConfig(ctx context.Context, authProvider provider.Auth, path string) er
 		return errors.WithStack(err)
 	}
 
-	answers, err := runConfigSurvey(ctx, authProvider, appName)
+	answers, err := cmdOpts.InitSurveyProvider().Run(ctx, authProvider, appName)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -110,7 +90,7 @@ func initConfig(ctx context.Context, authProvider provider.Auth, path string) er
 		return nil
 	}
 
-	if answers.ClusterOption == createJetpackCluster {
+	if answers.ClusterOption == provider.CreateJetpackCluster {
 		// Ask users to create a cluster first.
 		jetlog.Logger(ctx).Printf("\nTo create a new cluster, run `launchpad cluster create <cluster_name>`.\n")
 		return nil
@@ -122,9 +102,9 @@ func initConfig(ctx context.Context, authProvider provider.Auth, path string) er
 		Services:      []jetconfig.Service{},
 	}
 
-	if answers.AppType == string(webServiceType) {
+	if answers.AppType == string(provider.WebServiceType) {
 		jetCfg.AddNewWebService(answers.AppName + "-" + jetconfig.WebType)
-	} else if answers.AppType == string(cronjobServiceType) {
+	} else if answers.AppType == string(provider.CronjobServiceType) {
 		jetCfg.AddNewCronService(
 			answers.AppName+"-"+jetconfig.CronType,
 			[]string{"/bin/sh", "-c", "date; echo Hello from Launchpad"},
@@ -132,7 +112,7 @@ func initConfig(ctx context.Context, authProvider provider.Auth, path string) er
 		)
 	}
 
-	if answers.ClusterOption != "" && answers.ClusterOption != createJetpackCluster {
+	if answers.ClusterOption != "" && answers.ClusterOption != provider.CreateJetpackCluster {
 		jetCfg.Cluster = answers.ClusterOption
 	}
 	if answers.ImageRepositoryLocation != "" {
@@ -156,173 +136,6 @@ func initConfig(ctx context.Context, authProvider provider.Auth, path string) er
 	return nil
 }
 
-func runConfigSurvey(
-	ctx context.Context,
-	authProvider provider.Auth,
-	appName string,
-) (*SurveyAnswers, error) {
-
-	clusters, err := cmdOpts.ClusterProvider().GetAll(ctx)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	clusterNames := []string{}
-	for _, c := range clusters {
-		clusterNames = append(clusterNames, c.GetName())
-	}
-	// In case user wants to log in and use a jetpack managed cluster.
-	clusterNames = append(clusterNames, jetpackManagedCluster)
-	// In case user wants to create a cluster.
-	clusterNames = append(clusterNames, createJetpackCluster)
-
-	qs, err := surveyQuestions(ctx, appName, clusterNames)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	answers := &SurveyAnswers{}
-
-	err = survey.Ask([]*survey.Question{qs["AppName"]}, &answers.AppName)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	err = survey.Ask([]*survey.Question{qs["AppType"]}, &answers.AppType)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	err = survey.Ask([]*survey.Question{qs["ClusterOption"]}, &answers.ClusterOption)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	if answers.ClusterOption == jetpackManagedCluster {
-		// Prompt users to log in.
-		ctx, err := authProvider.Identify(ctx)
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-		// Get all the cluster names again.
-		clusters, err := cmdOpts.ClusterProvider().GetAll(ctx)
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-
-		// Only show the jetpack managed cluster names.
-		clusterNames := []string{}
-		for _, c := range clusters {
-			if c.IsJetpackManaged() {
-				clusterNames = append(clusterNames, c.GetName())
-			}
-		}
-		if len(clusterNames) == 0 {
-			answers.ClusterOption = createJetpackCluster
-		} else {
-			// Add option to select creating a new managed cluster.
-			clusterNames = append(clusterNames, createJetpackCluster)
-			additionalClusterSurvey := surveyJetpackManagedClusterQuestions(ctx, clusterNames)
-			err = survey.Ask([]*survey.Question{additionalClusterSurvey["ClusterOption"]}, &answers.ClusterOption)
-			if err != nil {
-				return nil, errors.WithStack(err)
-			}
-		}
-	}
-
-	return answers, nil
-}
-
-func surveyQuestions(ctx context.Context, appName string, clusterNames []string) (map[string]*survey.Question, error) {
-
-	appTypes := jetconfig.GetServiceTypes()
-	appTypeOptions := getAppTypeOptions(appTypes)
-
-	questions := map[string]*survey.Question{
-		"AppName": {
-			Name: "AppName",
-			Prompt: &survey.Input{
-				Message: "What is the name of this project?",
-				Default: appName,
-			},
-			Validate: func(val any) error {
-				if err := survey.MinLength(3)(val); err != nil {
-					return err
-				}
-
-				nameEntered := val.(string)
-				if ok := kubevalidate.IsValidName(nameEntered); !ok {
-					// NOTE: we can create an API `kubevalidate.IsValidNameWithReasons` that returns
-					// the error messages from k8s.io/apimachinery/pkg/util/validation
-					// However, those messages speak about DNS RFC 1035, which may be confusing
-					// to our users.
-
-					// The default error text by the Survey lib is prefixed by:
-					// X Sorry, your reply was invalid:
-					// to which we are adding a suffix of the nameEntered via the %s below.
-					// This gives feedback to the user that we actually processed their entered name.
-					msg := "%s\n" +
-						"For compatibility with kubernetes, we require app names to be:\n" +
-						" - less than 64 characters\n" +
-						" - consist of lower case alphanumeric characters or '-'\n" +
-						" - start with an alphabetic character \n" +
-						" - end with an alphanumeric character"
-					return fmt.Errorf(msg, nameEntered)
-				}
-				return nil
-			},
-		},
-		"AppType": {
-			Name: "AppType",
-			Prompt: &survey.Select{
-				Message: "What type of service you would like to add to this project?",
-				Options: appTypeOptions,
-			},
-		},
-		"ClusterOption": {
-			Name: "ClusterOption",
-			Prompt: &survey.Select{
-				Message: "To which cluster do you want to deploy this project?",
-				Options: clusterNames,
-			},
-		},
-		"ImageRepositoryLocation": {
-			Name: "ImageRepositoryLocation",
-			Prompt: &survey.Input{
-				Message: imageRepositoryFlagHelpMsg,
-			},
-			Validate: survey.Required,
-		},
-	}
-
-	return questions, nil
-}
-
-func surveyJetpackManagedClusterQuestions(ctx context.Context, clusterNames []string) map[string]*survey.Question {
-	return map[string]*survey.Question{
-		"ClusterOption": {
-			Name: "ClusterOption",
-			Prompt: &survey.Select{
-				Message: "To which jetpack managed cluster do you want to deploy this project?",
-				Options: clusterNames,
-			},
-		},
-	}
-}
-
 func appName(path string) (string, error) {
 	return kubevalidate.ToValidName(filepath.Base(jetconfig.ConfigDir(path)))
-}
-
-func getAppTypeOptions(appTypes []string) []string {
-	var appTypeOptions []string
-	for _, appType := range appTypes {
-		switch appType {
-		case jetconfig.WebType:
-			appTypeOptions = append(appTypeOptions, string(webServiceType))
-		case jetconfig.CronType:
-			appTypeOptions = append(appTypeOptions, string(cronjobServiceType))
-		}
-	}
-	return appTypeOptions
 }

--- a/padcli/command/mock/cmdopts.go
+++ b/padcli/command/mock/cmdopts.go
@@ -52,6 +52,10 @@ func (*MockCmdOptions) Hooks() *hook.Hooks {
 	return hook.New()
 }
 
+func (*MockCmdOptions) InitSurveyProvider() provider.InitSurveyProvider {
+	return provider.DefaultInitSurveyProvider(&mockClusterProvider{})
+}
+
 func (*MockCmdOptions) RepositoryProvider() provider.Repository {
 	return provider.EmptyRepository()
 }

--- a/padcli/command/up.go
+++ b/padcli/command/up.go
@@ -155,7 +155,7 @@ func registerPublishFlags(cmd *cobra.Command, opts *publishOptions) {
 		"image-repository",
 		"i",
 		"",
-		imageRepositoryFlagHelpMsg,
+		provider.ImageRepositoryFlagHelpMsg,
 	)
 }
 

--- a/padcli/provider/initsurveyprovider.go
+++ b/padcli/provider/initsurveyprovider.go
@@ -1,0 +1,174 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/pkg/errors"
+	"go.jetpack.io/launchpad/padcli/jetconfig"
+	"go.jetpack.io/launchpad/pkg/kubevalidate"
+)
+
+type serviceTypeOption string
+
+const (
+	WebServiceType             serviceTypeOption = "Web Service"
+	CronjobServiceType         serviceTypeOption = "Cron Job"
+	JetpackManagedCluster      string            = "Jetpack managed cluster"
+	CreateJetpackCluster       string            = "Create a new cluster with Jetpack"
+	ImageRepositoryFlagHelpMsg                   = "Image repository to push the built image to. " +
+		"Your kubernetes cluster must have the permissions to pull images from this repository."
+)
+
+type SurveyAnswers struct {
+	AppName                 string
+	AppType                 string
+	ClusterOption           string
+	KubeContext             string
+	ImageRepositoryLocation string
+}
+
+type InitSurveyProvider interface {
+	Run(
+		ctx context.Context,
+		authProvider Auth,
+		appName string,
+	) (*SurveyAnswers, error)
+}
+
+type initSurveyProvider struct {
+	ClusterProvider ClusterProvider
+}
+
+func DefaultInitSurveyProvider(cp ClusterProvider) InitSurveyProvider {
+	return &initSurveyProvider{cp}
+}
+
+func (p *initSurveyProvider) Run(
+	ctx context.Context,
+	authProvider Auth,
+	appName string,
+) (*SurveyAnswers, error) {
+
+	clusters, err := p.ClusterProvider.GetAll(ctx)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	clusterNames := []string{}
+	for _, c := range clusters {
+		clusterNames = append(clusterNames, c.GetName())
+	}
+	// In case user wants to log in and use a jetpack managed cluster.
+	clusterNames = append(clusterNames, JetpackManagedCluster)
+	// In case user wants to create a cluster.
+	clusterNames = append(clusterNames, CreateJetpackCluster)
+
+	qs, err := surveyQuestions(ctx, appName, clusterNames)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	answers := &SurveyAnswers{}
+
+	// These questions could be moved to the survey provider
+	err = survey.Ask([]*survey.Question{qs["AppName"]}, &answers.AppName)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	err = survey.Ask([]*survey.Question{qs["AppType"]}, &answers.AppType)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	err = survey.Ask([]*survey.Question{qs["ClusterOption"]}, &answers.ClusterOption)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return answers, nil
+}
+
+func surveyQuestions(
+	ctx context.Context,
+	appName string,
+	clusterNames []string,
+) (map[string]*survey.Question, error) {
+
+	appTypes := jetconfig.GetServiceTypes()
+	appTypeOptions := getAppTypeOptions(appTypes)
+
+	questions := map[string]*survey.Question{
+		"AppName": {
+			Name: "AppName",
+			Prompt: &survey.Input{
+				Message: "What is the name of this project?",
+				Default: appName,
+			},
+			Validate: func(val any) error {
+				if err := survey.MinLength(3)(val); err != nil {
+					return err
+				}
+
+				nameEntered := val.(string)
+				if ok := kubevalidate.IsValidName(nameEntered); !ok {
+					// NOTE: we can create an API `kubevalidate.IsValidNameWithReasons` that returns
+					// the error messages from k8s.io/apimachinery/pkg/util/validation
+					// However, those messages speak about DNS RFC 1035, which may be confusing
+					// to our users.
+
+					// The default error text by the Survey lib is prefixed by:
+					// X Sorry, your reply was invalid:
+					// to which we are adding a suffix of the nameEntered via the %s below.
+					// This gives feedback to the user that we actually processed their entered name.
+					msg := "%s\n" +
+						"For compatibility with kubernetes, we require app names to be:\n" +
+						" - less than 64 characters\n" +
+						" - consist of lower case alphanumeric characters or '-'\n" +
+						" - start with an alphabetic character \n" +
+						" - end with an alphanumeric character"
+					return fmt.Errorf(msg, nameEntered)
+				}
+				return nil
+			},
+		},
+		"AppType": {
+			Name: "AppType",
+			Prompt: &survey.Select{
+				Message: "What type of service you would like to add to this project?",
+				Options: appTypeOptions,
+			},
+		},
+		"ClusterOption": {
+			Name: "ClusterOption",
+			Prompt: &survey.Select{
+				Message: "To which cluster do you want to deploy this project?",
+				Options: clusterNames,
+			},
+		},
+		"ImageRepositoryLocation": {
+			Name: "ImageRepositoryLocation",
+			Prompt: &survey.Input{
+				Message: ImageRepositoryFlagHelpMsg,
+			},
+			Validate: survey.Required,
+		},
+	}
+
+	return questions, nil
+}
+
+func getAppTypeOptions(appTypes []string) []string {
+	var appTypeOptions []string
+	for _, appType := range appTypes {
+		switch appType {
+		case jetconfig.WebType:
+			appTypeOptions = append(appTypeOptions, string(WebServiceType))
+		case jetconfig.CronType:
+			appTypeOptions = append(appTypeOptions, string(CronjobServiceType))
+		}
+	}
+	return appTypeOptions
+}

--- a/padcli/provider/provider.go
+++ b/padcli/provider/provider.go
@@ -7,6 +7,7 @@ type Providers interface {
 	ClusterProvider() ClusterProvider
 	EnvSecProvider() EnvSec
 	ErrorLogger() ErrorLogger
+	InitSurveyProvider() InitSurveyProvider
 	NamespaceProvider() NamespaceProvider
 	RepositoryProvider() Repository
 }


### PR DESCRIPTION
## Summary

This splits out init survey into a provider.

I think there's a few more follow ups we can do after this that will make it better, for example `answers.ClusterOption == provider.CreateJetpackCluster` condition can be removed (we could add a generic non error println to `answers`)

## How was it tested?

* linter

## Is this change backwards-compatible?
yes