### PR TITLE
Fix commands to set cluster properly before identifying the user

### DIFF
--- a/padcli/command/build.go
+++ b/padcli/command/build.go
@@ -43,16 +43,15 @@ func buildCmd() *cobra.Command {
 		Args:   cobra.MaximumNArgs(1),
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, err := cmdOpts.AuthProvider().Identify(cmd.Context())
-			if err != nil {
-				return errors.WithStack(err)
-			}
-
 			p, err := projectDir(args)
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			jetCfg, err := loadOrInitConfigFromFileSystem(ctx, cmd, args)
+			jetCfg, err := loadOrInitConfigFromFileSystem(cmd.Context(), cmd, args)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			ctx, err := cmdOpts.AuthProvider().Identify(cmd.Context())
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/padcli/command/dev.go
+++ b/padcli/command/dev.go
@@ -41,15 +41,21 @@ func devCmd() *cobra.Command {
 		Hidden:  true,
 		PreRunE: validateDeployUptions(&opts.deployOptions),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			absPath, err := projectDir(args)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+
+			_, err = loadOrInitConfigFromFileSystem(cmd.Context(), cmd, args)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+
 			ctx, err := cmdOpts.AuthProvider().Identify(cmd.Context())
 			if err != nil {
 				return errors.WithStack(err)
 			}
 
-			absPath, err := projectDir(args)
-			if err != nil {
-				return errors.WithStack(err)
-			}
 			fsChanges, err := listenToFilesystemChanges(ctx, absPath)
 			if err != nil {
 				return errors.Wrap(err, "failed to listen to filesystem changes")

--- a/padcli/command/down.go
+++ b/padcli/command/down.go
@@ -25,18 +25,17 @@ func downCmd() *cobra.Command {
 			"associated resources.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, err := cmdOpts.AuthProvider().Identify(cmd.Context())
-			if err != nil {
-				return errors.WithStack(err)
-			}
-
-			c, err := RequireConfigFromFileSystem(ctx, cmd, args, cmdOpts)
+			c, err := RequireConfigFromFileSystem(cmd.Context(), cmd, args, cmdOpts)
 			if errors.Is(err, jetconfig.ErrConfigNotFound) {
 				return errorutil.NewUserError(
 					"jetconfig not found. Please run `launchpad down` in launchpad project " +
 						"directory or pass path to directory as parameter.",
 				)
 			} else if err != nil {
+				return errors.WithStack(err)
+			}
+			ctx, err := cmdOpts.AuthProvider().Identify(cmd.Context())
+			if err != nil {
 				return errors.WithStack(err)
 			}
 			do, err := makeLaunchpadDownOptions(ctx, c, flags)

--- a/padcli/command/env.go
+++ b/padcli/command/env.go
@@ -33,12 +33,8 @@ func envCmd() *cobra.Command {
 			store values that contain passwords and other secrets.
 		`),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			ctx, err := cmdOpts.AuthProvider().Identify(cmd.Context())
-			if err != nil {
-				return errors.WithStack(err)
-			}
-
-			absProjectPath := ""
+			var absProjectPath string
+			var err error
 			if opts.projectConfigPath == "" {
 				absProjectPath, err = getProjectDir()
 			} else {
@@ -48,7 +44,12 @@ func envCmd() *cobra.Command {
 				return errors.WithStack(err)
 			}
 
-			jetCfg, err := RequireConfigFromFileSystem(ctx, cmd, []string{absProjectPath}, cmdOpts)
+			jetCfg, err := RequireConfigFromFileSystem(cmd.Context(), cmd, []string{absProjectPath}, cmdOpts)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+
+			ctx, err := cmdOpts.AuthProvider().Identify(cmd.Context())
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/padcli/command/local.go
+++ b/padcli/command/local.go
@@ -26,17 +26,17 @@ func localCmd() *cobra.Command {
 		Args:   cobra.MaximumNArgs(1),
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, err := cmdOpts.AuthProvider().Identify(cmd.Context())
-			if err != nil {
-				return errors.WithStack(err)
-			}
-
 			absPath, err := projectDir(args)
 			if err != nil {
 				return errors.WithStack(err)
 			}
 
-			jetCfg, err := loadOrInitConfigFromFileSystem(ctx, cmd, args)
+			jetCfg, err := loadOrInitConfigFromFileSystem(cmd.Context(), cmd, args)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+
+			ctx, err := cmdOpts.AuthProvider().Identify(cmd.Context())
 			if err != nil {
 				return errors.WithStack(err)
 			}


### PR DESCRIPTION
## Summary
Fix commands to set cluster properly before identifying the user. Now that we rely on `setClusterName` before `Identify` call. 

Specifically, `authProvider.Identify` needs to happen after `loadOrInitConfigFromFileSystem`

## How was it tested?
launchpad up
launchpad env
...
and all the commands affected

## Is this change backwards-compatible?
yes