### PR TITLE
Expose registry host to helm hooks DEV-1249

### DIFF
--- a/launchpad/publish.go
+++ b/launchpad/publish.go
@@ -114,6 +114,7 @@ type PublishPlan struct {
 
 type PublishOutput struct {
 	Duration        time.Duration
+	RegistryHost    registryHost
 	publishedImages map[string]string
 }
 
@@ -127,6 +128,10 @@ func (p *PublishImagePlan) remoteImageNameWithTag() string {
 
 func (p *PublishImagePlan) remoteImageNameWithLatestTag() string {
 	return fmt.Sprintf("%s:%s", p.remoteImageName, "latest")
+}
+
+func (ir *ImageRegistry) GetHost() registryHost {
+	return ir.host
 }
 
 func (o *PublishOutput) DidPublish() bool {
@@ -472,7 +477,10 @@ func (p *Pad) publishDockerImage(
 		published[image.localImage.String()] = image.remoteImageNameWithTag()
 	}
 
-	return &PublishOutput{publishedImages: published}, nil
+	return &PublishOutput{
+		publishedImages: published,
+		RegistryHost:    plan.registry.GetHost(),
+	}, nil
 }
 
 func makePublishPlan(

--- a/padcli/command/deploy.go
+++ b/padcli/command/deploy.go
@@ -63,6 +63,7 @@ func makeDeployOptions(
 		helm.NewImageProvider(
 			buildOutput.Image.String(),
 			publishOutput.PublishedImages(),
+			string(publishOutput.RegistryHost),
 		),
 		jetCfg,
 		cluster,
@@ -83,7 +84,6 @@ func makeDeployOptions(
 	if err := hvc.Compute(ctx); err != nil {
 		return nil, errors.Wrap(err, "failed to compute helm values")
 	}
-
 	appValues, err := cmdOpts.Hooks().PostAppChartValuesCompute(
 		ctx,
 		cmdOpts,
@@ -92,7 +92,6 @@ func makeDeployOptions(
 	if err != nil {
 		return nil, err
 	}
-
 	runtimeValues, err := cmdOpts.Hooks().PostRuntimeChartValuesCompute(
 		ctx,
 		cmdOpts,

--- a/padcli/helm/helm.go
+++ b/padcli/helm/helm.go
@@ -63,6 +63,10 @@ func (hvc *ValueComputer) RuntimeValues() map[string]any {
 	return hvc.runtimeValues
 }
 
+func (hvc *ValueComputer) ImageProvider() *ImageProvider {
+	return hvc.imageProvider
+}
+
 // Compute converts command options to helm values.
 func (hvc *ValueComputer) Compute(ctx context.Context) error {
 	hvc.appValues = map[string]any{}

--- a/padcli/helm/images.go
+++ b/padcli/helm/images.go
@@ -10,6 +10,8 @@ type ImageProvider struct {
 	// Should include tag if it exists
 	defaultLocalImage string
 
+	imageRegistryHost string
+
 	// For published images, key is local image, value is published image
 	imagePublishMap map[string]string
 }
@@ -17,11 +19,17 @@ type ImageProvider struct {
 func NewImageProvider(
 	defaultLocalImage string,
 	imagePublishMap map[string]string,
+	imageRegistryHost string,
 ) *ImageProvider {
 	return &ImageProvider{
 		defaultLocalImage: defaultLocalImage,
 		imagePublishMap:   imagePublishMap,
+		imageRegistryHost: imageRegistryHost,
 	}
+}
+
+func (i *ImageProvider) GetRegistryHost() string {
+	return i.imageRegistryHost
 }
 
 func (i *ImageProvider) get(c provider.Cluster, img string) string {


### PR DESCRIPTION
## Summary
Expose registry host information for helm hooks to access.

## How was it tested?
launchpad up on BYOC + custom ECR

## Is this change backwards-compatible?
Yes