### PR TITLE
Create namespace for non-managed clusters

### DIFF
--- a/launchpad/deploy.go
+++ b/launchpad/deploy.go
@@ -59,7 +59,8 @@ type DeployOptions struct {
 
 	LifecycleHook hook.LifecycleHook
 
-	Namespace string
+	Namespace       string
+	CreateNamespace bool
 
 	RemoteEnvVars map[string]string
 	Runtime       *HelmOptions

--- a/padcli/command/deploy.go
+++ b/padcli/command/deploy.go
@@ -162,6 +162,7 @@ func makeDeployOptions(
 			Values:        appValues,
 			Timeout:       lo.Ternary(len(jetCfg.Jobs()) > 0, 5*time.Minute, 0),
 		},
+		CreateNamespace:             !cluster.IsJetpackManaged(),
 		Environment:                 cmdOpts.RootFlags().Env().String(),
 		ExternalCharts:              jetconfigHelmToChartConfig(jetCfg, ns),
 		JetCfg:                      jetCfg,

--- a/padcli/helm/helm.go
+++ b/padcli/helm/helm.go
@@ -13,15 +13,6 @@ import (
 	"go.jetpack.io/launchpad/proto/api"
 )
 
-// type cluster interface {
-// 	GetHostname() string
-// 	GetIsPrivate() bool
-// 	GetName() string
-// 	IsLocal() bool
-// 	IsJetpackManaged() bool
-// 	IsRemoteUnmanaged() bool
-// }
-
 // ValueComputer transforms jetpack CLI inputs into helm values.
 // Right now we mostly copy paste the logic, but the idea is to have individual
 // modules that compute sections of the values. e.g. ambassadorModule, cronjobModule, etc.


### PR DESCRIPTION
## Summary

For non-managed clusters, Helm should create the namespace (if it doesn't already exist).

## How was it tested?
TODO

## Is this change backwards-compatible?
Yes