### PR TITLE
Always set Helm's create-namespace to true

### DIFF
--- a/launchpad/helm.go
+++ b/launchpad/helm.go
@@ -121,9 +121,9 @@ func installHelmChart(
 
 	install.Namespace = cc.Namespace
 	install.ReleaseName = cc.Release
-	// For Jetpack-managed clusters, namespace is created (and permissions are set) by InitNamespace. And we
-	// cannot set --create-namespace=true because multi-tenant cluster users won't have permissions.
-
+	// For Jetpack-managed clusters, namespace is created (and permissions are set) by InitNamespace, so this
+	// will be a no-op. For other clusters, we set to true in case the namespace doesn't exist yet.
+	install.CreateNamespace = true
 	install.Wait = cc.Wait
 	install.Timeout = cc.Timeout
 


### PR DESCRIPTION
## Summary
TSIA

Closes DEV-1252.

## How was it tested?
Tested that (1) `launchpad up` with a new namespace on a jetpack-managed cluster creates the namespace and permissions are set correctly; (2) `launchpad up` with a new namespace on a BYOC cluster creates the namespace; permissions are not set, which is fine.

## Is this change backwards-compatible?
Yes