### PR TITLE
Allow setting of Helm --create-namespace

### DIFF
--- a/launchpad/deploy.go
+++ b/launchpad/deploy.go
@@ -59,7 +59,8 @@ type DeployOptions struct {
 
 	LifecycleHook hook.LifecycleHook
 
-	Namespace string
+	Namespace       string
+	CreateNamespace bool
 
 	RemoteEnvVars map[string]string
 	Runtime       *HelmOptions

--- a/launchpad/helm.go
+++ b/launchpad/helm.go
@@ -123,8 +123,10 @@ func installHelmChart(
 
 	install.Namespace = cc.Namespace
 	install.ReleaseName = cc.Release
-	// For Jetpack-managed clusters, namespace is created (and permissions are set) by InitNamespace. And we
-	// cannot set --create-namespace=true because multi-tenant cluster users won't have permissions.
+	// Setting --create-namespace=true makes Helm attempt to create the namespace and continue if it already
+	// exists, but it will fail if the user lacks permissions to create namespaces. Thus, we cannot set this
+	// to true every time, because it might fail for managed multi-tenant clusters where a user's permissions
+	// are limited.
 	install.CreateNamespace = createNamespace
 
 	install.Wait = cc.Wait

--- a/padcli/command/deploy.go
+++ b/padcli/command/deploy.go
@@ -162,7 +162,7 @@ func makeDeployOptions(
 			Values:        appValues,
 			Timeout:       lo.Ternary(len(jetCfg.Jobs()) > 0, 5*time.Minute, 0),
 		},
-		CreateNamespace:             !cluster.IsJetpackManaged(),
+		CreateNamespace:             hvc.CreateNamespace(),
 		Environment:                 cmdOpts.RootFlags().Env().String(),
 		ExternalCharts:              jetconfigHelmToChartConfig(jetCfg, ns),
 		JetCfg:                      jetCfg,

--- a/padcli/command/deploy.go
+++ b/padcli/command/deploy.go
@@ -162,6 +162,7 @@ func makeDeployOptions(
 			Values:        appValues,
 			Timeout:       lo.Ternary(len(jetCfg.Jobs()) > 0, 5*time.Minute, 0),
 		},
+		CreateNamespace:             !cluster.IsJetpackManaged(),
 		Environment:                 cmdOpts.RootFlags().Env().String(),
 		ExternalCharts:              jetconfigHelmToChartConfig(jetCfg, ns),
 		JetCfg:                      jetCfg,

--- a/padcli/helm/helm.go
+++ b/padcli/helm/helm.go
@@ -13,15 +13,6 @@ import (
 	"go.jetpack.io/launchpad/proto/api"
 )
 
-// type cluster interface {
-// 	GetHostname() string
-// 	GetIsPrivate() bool
-// 	GetName() string
-// 	IsLocal() bool
-// 	IsJetpackManaged() bool
-// 	IsRemoteUnmanaged() bool
-// }
-
 // ValueComputer transforms jetpack CLI inputs into helm values.
 // Right now we mostly copy paste the logic, but the idea is to have individual
 // modules that compute sections of the values. e.g. ambassadorModule, cronjobModule, etc.

--- a/padcli/helm/helm.go
+++ b/padcli/helm/helm.go
@@ -22,6 +22,7 @@ type ValueComputer struct {
 
 	env                 api.Environment
 	namespace           string // The final namespace to be used
+	createNamespace     bool   // Value used for helm's --create-namespace
 	execQualifiedSymbol string // Used by jetpack dev <path/to/project> --exec <symbol>
 	imageProvider       *ImageProvider
 	jetCfg              *jetconfig.Config // consider interface
@@ -206,6 +207,14 @@ func (hvc *ValueComputer) Environment() api.Environment {
 
 func (hvc *ValueComputer) Namespace() string {
 	return hvc.namespace
+}
+
+func (hvc *ValueComputer) CreateNamespace() bool {
+	return hvc.createNamespace
+}
+
+func (hvc *ValueComputer) SetCreateNamespace(createNamespace bool) {
+	hvc.createNamespace = createNamespace
 }
 
 func (hvc *ValueComputer) Cluster() provider.Cluster {


### PR DESCRIPTION
## Summary

HelmValueComputer now has settable `createNamespace`, which we pass to Helm when installing charts.

This is the implementation of the suggestion in https://github.com/jetpack-io/launchpad/pull/20#issuecomment-1314545068

Partially closes DEV-1252.

## How was it tested?
`launchpad up` with a BYOC cluster, and with a managed cluster.

## Is this change backwards-compatible?
Yes