### PR TITLE
Consolidate flags for all commands

### DIFF
--- a/padcli/command/build.go
+++ b/padcli/command/build.go
@@ -118,6 +118,7 @@ func registerEmbeddedBuildFlags(cmd *cobra.Command, opts *embeddedBuildOptions) 
 			"adds BUILDKIT_INLINE_CACHE=1 build arg to save cache metadata and also "+
 			"sets the cache-from docker build option",
 	)
+	_ = cmd.Flags().MarkHidden("remote-cache")
 
 	cmd.Flags().StringVar(
 		&opts.LocalImage,

--- a/padcli/command/env.go
+++ b/padcli/command/env.go
@@ -15,12 +15,7 @@ import (
 	"go.jetpack.io/launchpad/pkg/jetlog"
 )
 
-type envOptions struct {
-	projectConfigPath string
-}
-
 func envCmd() *cobra.Command {
-	opts := &envOptions{}
 	cmdCfg := &envcli.CmdConfig{}
 	command := &cobra.Command{
 		Use:   "env",
@@ -31,15 +26,12 @@ func envCmd() *cobra.Command {
 			Securely stores and retrieves environment variables on the cloud.
 			Environment variables are always encrypted, which makes it possible to
 			store values that contain passwords and other secrets.
+
+			This command can only be run within a Launchpad project's directory (the directory
+			where launchpad.yaml is present)
 		`),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			var absProjectPath string
-			var err error
-			if opts.projectConfigPath == "" {
-				absProjectPath, err = getProjectDir()
-			} else {
-				absProjectPath, err = absPath([]string{opts.projectConfigPath})
-			}
+			absProjectPath, err := getProjectDir()
 			if err != nil {
 				return errors.WithStack(err)
 			}
@@ -79,14 +71,6 @@ func envCmd() *cobra.Command {
 			return errors.WithStack(cmd.Help())
 		},
 	}
-
-	command.PersistentFlags().StringVarP(
-		&opts.projectConfigPath,
-		"project",
-		"p",
-		"",
-		"Path to project config. If directory, we assume name is launchpad.yaml",
-	)
 
 	command.AddCommand(
 		envcli.SetCmd(cmdCfg),

--- a/padcli/command/up.go
+++ b/padcli/command/up.go
@@ -181,12 +181,15 @@ func registerDeployFlags(cmd *cobra.Command, opts *deployOptions) {
 		"",
 		"custom location for app chart",
 	)
+	_ = cmd.Flags().MarkHidden("helm.app.chart-location")
+
 	cmd.Flags().StringVar(
 		&opts.App.Name,
 		"helm.app.name",
 		"",
 		"App install name",
 	)
+	_ = cmd.Flags().MarkHidden("helm.app.name")
 
 	cmd.Flags().StringVar(
 		&opts.Runtime.SetValues,
@@ -194,12 +197,15 @@ func registerDeployFlags(cmd *cobra.Command, opts *deployOptions) {
 		"",
 		"args passed to helm --set option for runtime (can specify multiple or separate values with commas: key1=val1,key2=val2)",
 	)
+	_ = cmd.Flags().MarkHidden("helm.runtime.set")
+
 	cmd.Flags().StringVar(
 		&opts.Runtime.ChartLocation,
 		"helm.runtime.chart-location",
 		"",
 		"custom location for runtime chart",
 	)
+	_ = cmd.Flags().MarkHidden("helm.runtime.chart-location")
 
 	cmd.Flags().StringVarP(
 		&opts.Namespace,
@@ -251,9 +257,6 @@ func registerDeployFlags(cmd *cobra.Command, opts *deployOptions) {
 		"",
 		envOverrideFlagMsg,
 	)
-	// Made env-override file flag hidden temporarily until we decide on concrete approach
-	// on whether override merges with launchpad env or skips it
-	_ = cmd.Flags().MarkHidden(envOverrideFlag)
 
 	cmd.Flags().StringVar(
 		&opts.execQualifiedSymbol,
@@ -261,6 +264,7 @@ func registerDeployFlags(cmd *cobra.Command, opts *deployOptions) {
 		"",
 		"Execute a single cronjob or jetroutine for a given function.",
 	)
+	_ = cmd.Flags().MarkHidden("exec")
 
 	cmd.Flags().BoolVar(
 		&opts.ReinstallOnHelmUpgradeError,

--- a/padcli/jetconfig/errors.go
+++ b/padcli/jetconfig/errors.go
@@ -2,5 +2,5 @@ package jetconfig
 
 import "github.com/pkg/errors"
 
-var ErrConfigNotFound = errors.New("jetconfig was not found")
+var ErrConfigNotFound = errors.New("jetconfig (launchpad.yaml) was not found")
 var ErrInvalidProjectID = errors.New("project ID is invalid")


### PR DESCRIPTION
## Summary
Consolidate flags for all commands

## How was it tested?
launchpad <cmd> --help

## Is this change backwards-compatible?
Yes