### PR TITLE
[polish] Print env help even if we're not in a project dir

### DIFF
--- a/padcli/command/env.go
+++ b/padcli/command/env.go
@@ -31,6 +31,12 @@ func envCmd() *cobra.Command {
 			where launchpad.yaml is present)
 		`),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.CalledAs() == "env" {
+				// Do not enforce being a project dir; instead let it through so the user
+				// can se the help text.
+				return nil
+			}
+
 			absProjectPath, err := getProjectDir()
 			if err != nil {
 				return errors.WithStack(err)


### PR DESCRIPTION
## Summary

Before:
```
> launchpad env
2022/11/16 14:35:55 ABORT: There was an error. The cause is:
	 'launchpad env' only works within a Launchpad project's directory. Please change your current directory to a Launchpad project and try again.
Run with --debug for more information
```

After:
```
> launchpad env
Manage environment variables and secrets

Securely stores and retrieves environment variables on the cloud.
...(clipped)
```

## How was it tested?
Running `launchpad env` and `launchpad env ls`

## Is this change backwards-compatible?
Yes