### PR TITLE
[init] Default app name if we can't use path DEV-1254

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -5,5 +5,8 @@
   ],
   "shell": {
     "init_hook": null
+  },
+  "nixpkgs": {
+    "commit": "af9e00071d0971eb292fd5abef334e66eda3cb69"
   }
 }

--- a/padcli/command/initcmd.go
+++ b/padcli/command/initcmd.go
@@ -68,7 +68,8 @@ func projectDir(args []string) (string, error) {
 func initConfig(ctx context.Context, authProvider provider.Auth, path string) error {
 	appName, err := appName(path)
 	if err != nil {
-		return errors.WithStack(err)
+		// Some paths can't be turned into a valid name (e.g. "/")
+		appName = "my-app"
 	}
 	// check if jetconfig file exists
 	_, err = jetconfig.RequireFromFileSystem(ctx, path, cmdOpts.RootFlags().Env())


### PR DESCRIPTION
## Summary

Some paths can't be turned into a valid name. Default with `my-app`

## How was it tested?

Ran `launchpad init` from root dir "/"

## Is this change backwards-compatible?
yes