### PR TITLE
[config] Fix legacy configs

### DIFF
--- a/padcli/helm/helm.go
+++ b/padcli/helm/helm.go
@@ -156,12 +156,16 @@ func (hvc *ValueComputer) Compute(ctx context.Context) error {
 		SetNestedField(hvc.appValues, "service", "type", "NodePort")
 	}
 
+	// Legacy configs don't have an explicit web service. We might still need
+	// to set image values in case it's a legacy config that publishes an image.
+	configImage := ""
 	if websvc != nil {
-		repo, tag := hvc.imageProvider.getSplit(hvc.cluster, websvc.GetImage())
-		hvc.appValues["image"] = map[string]any{
-			"repository": repo,
-			"tag":        tag,
-		}
+		configImage = websvc.GetImage()
+	}
+	repo, tag := hvc.imageProvider.getSplit(hvc.cluster, configImage)
+	hvc.appValues["image"] = map[string]any{
+		"repository": repo,
+		"tag":        tag,
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

This fixes legacy configs that specify web-like services without using the `services` field. For example, using the jetpack SDK you can define some cronjobs in your code and publish a docker image. This doesn't need replicas or a deployment but does need the `image` field to be set in the app helm chart (because the register SDK job uses this field).

## How was it tested?

Tested `launchpad up` on a few projects:

* Project with legacy config that uses jetpack SDK with cronjobs
* Project with new config that publishes image. (with and without web type) 
* Project with new config that does not publish image.

## Is this change backwards-compatible?

Yes
