### PR TITLE
[errors] Don't re-wrap user errors DEV-1276

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -1,12 +1,21 @@
 {
   "packages": [
     "go_1_19",
-    "buf"
+    "buf",
+    "golangci-lint"
   ],
   "shell": {
-    "init_hook": null
+    "init_hook": [
+      "export \"GOROOT=$(go env GOROOT)\"",
+      "export \"PATH=$(pwd)/dist:$PATH\""
+    ],
+    "scripts": {
+      "build": "go build -o dist/launchpad cmd/launchpad/main.go",
+      "lint": "golangci-lint run",
+      "test": "go test -race -cover ./..."
+    }
   },
   "nixpkgs": {
-    "commit": "af9e00071d0971eb292fd5abef334e66eda3cb69"
+    "commit": "3954218cf613eba8e0dcefa9abe337d26bc48fd0"
   }
 }

--- a/goutil/errorutil/usererror_test.go
+++ b/goutil/errorutil/usererror_test.go
@@ -1,0 +1,58 @@
+package errorutil
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestHasUserError(t *testing.T) {
+	err := NewUserError("test")
+	if !hasUserError(err) {
+		t.Errorf("got HasUserError(%q) = false, want true.", err)
+	}
+
+	combined := CombinedError(errors.New("rand"), NewUserError("test"))
+	if !hasUserError(combined) {
+		t.Errorf("got HasUserError(%q) = false, want true.", combined)
+	}
+
+	notUserError := errors.New("no user error")
+	if hasUserError(notUserError) {
+		t.Errorf("got HasUserError(%q) = true, want false.", notUserError)
+	}
+}
+
+func TestDontRewrapUserError(t *testing.T) {
+	err1 := NewUserError("test")
+	err2 := NewUserError("test")
+	userErr := CombinedError(err1, err2)
+	// nolint:errorlint
+	if userErr != err1 {
+		t.Errorf("got CombinedError(%q, %q) = %q, want %q.", err1, err2, userErr, err1)
+	}
+
+	userErr = AddUserMessagef(err1, "test")
+	// nolint:errorlint
+	if userErr != err1 {
+		t.Errorf("got AddUserMessagef(%q) = %q, want %q.", err1, userErr, err1)
+	}
+}
+
+func TestAddUserMessagef(t *testing.T) {
+	err := errors.New("test")
+	userMessage := "test-user"
+	userErr := AddUserMessagef(err, userMessage)
+	// nolint:errorlint
+	if userErr == err {
+		t.Errorf("got AddUserMessagef(%q) = %q, want not %q.", err, userErr, err)
+	}
+	if GetUserErrorMessage(userErr) != userMessage {
+		t.Errorf(
+			"got GetUserErrorMessage(%q) = %q, want %q.",
+			userErr,
+			GetUserErrorMessage(userErr),
+			"test",
+		)
+	}
+}


### PR DESCRIPTION
## Summary

Re-wrapping user errors causes the original source error to be obscured, we never want to do it. While returning the original error means we're ignoring the secondary user error this is OK because the original error is usually the actionable one.

## How was it tested?

go test -race -cover ./goutil/errorutil/...

## Is this change backwards-compatible?
Yes