### PR TITLE
[init] Fix init when period in dir

### DIFF
--- a/padcli/jetconfig/jetconfig.go
+++ b/padcli/jetconfig/jetconfig.go
@@ -61,13 +61,15 @@ type Config struct {
 // if the file doesn't exist
 func isPathFormatAConfigFile(path string) bool {
 	fi, err := os.Stat(path)
-	if err == nil && !fi.IsDir() {
-		return true
+	if err == nil {
+		// path already exists. If it's a dir it can't be a config file. If
+		// it's a file assume it's a config file.
+		return !fi.IsDir()
 	}
-	// Handle new configs:
-	// There's probably better more general ways to do this, but this if ok for
-	// now. Assume that if base contains a period it's a file.
-	return strings.ContainsRune(filepath.Base(path), '.')
+
+	// If path doesn't exist, always assume it's a config file. if more than the
+	// base of the path doesn't exist this will fail and that's ok.
+	return true
 }
 
 func configPath(path string) string {


### PR DESCRIPTION
## Summary

If path is a dir we know it can't be a config. Previously, we would say it's a config if there was a period in the name.

## How was it tested?

`mkdir foo.bar && ./dist/launchpad/launchpad init foo.bar`

## Is this change backwards-compatible?
yes