### PR TITLE
[easy][cronjobs] Add support for cronjob concurrencyPolicy

### DIFF
--- a/padcli/helm/helm.go
+++ b/padcli/helm/helm.go
@@ -98,10 +98,11 @@ func (hvc *ValueComputer) Compute(ctx context.Context) error {
 		hvc.jetCfg.Cronjobs(),
 		func(cj jetconfig.Cron, _ int) any {
 			return map[string]any{
-				"name":     ToValidName(cj.GetUniqueName()),
-				"schedule": cj.GetSchedule(),
-				"image":    hvc.imageProvider.get(hvc.cluster, cj.GetImage()),
-				"command":  cj.GetCommand(),
+				"name":              ToValidName(cj.GetUniqueName()),
+				"schedule":          cj.GetSchedule(),
+				"concurrencyPolicy": cj.GetConcurrencyPolicy(),
+				"image":             hvc.imageProvider.get(hvc.cluster, cj.GetImage()),
+				"command":           cj.GetCommand(),
 				"resources": map[string]any{
 					"requests": map[string]any{
 						"cpu":    cj.GetInstanceType().Compute(),

--- a/padcli/jetconfig/cron.go
+++ b/padcli/jetconfig/cron.go
@@ -5,6 +5,7 @@ type Cron interface {
 	Builder
 	Service
 	GetSchedule() string
+	GetConcurrencyPolicy() string
 	GetCommand() []string
 }
 
@@ -32,16 +33,24 @@ func (c *Config) AddNewCronService(
 
 // Private cron struct
 type cron struct {
-	service  `yaml:",inline,omitempty"`
-	builder  `yaml:",inline,omitempty"`
-	Command  []string `yaml:"command,omitempty,flow"`
-	Schedule string   `yaml:"schedule,omitempty"`
+	service          `yaml:",inline,omitempty"`
+	builder          `yaml:",inline,omitempty"`
+	Command          []string `yaml:"command,omitempty,flow"`
+	Schedule         string   `yaml:"schedule,omitempty"`
+	ConcurrentPolicy string   `yaml:"concurrencyPolicy,omitempty"`
 }
 
 var _ Cron = (*cron)(nil)
 
 func (c *cron) GetSchedule() string {
 	return c.Schedule
+}
+
+func (c *cron) GetConcurrencyPolicy() string {
+	if c.ConcurrentPolicy == "" {
+		return "Allow" // k8s default
+	}
+	return c.ConcurrentPolicy
 }
 
 func (c *cron) GetCommand() []string {


### PR DESCRIPTION
## Summary

Adds support for cronjob [concurrency policy](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-suspension)

## How was it tested?

builds

## Is this change backwards-compatible?
Yes
