### PR TITLE
[docker] Make docker cli default way to build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.18.7
 	github.com/bep/debounce v1.2.1
 	github.com/briandowns/spinner v1.23.0
-	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/containerd/containerd v1.7.2
 	github.com/docker/cli v23.0.6+incompatible
 	github.com/docker/docker v23.0.6+incompatible
@@ -154,7 +153,6 @@ require (
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/patternmatcher v0.5.0 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
-	github.com/moby/sys/sequential v0.5.0 // indirect
 	github.com/moby/sys/signal v0.7.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,6 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
-github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
-github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -585,7 +583,6 @@ github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
 github.com/moby/sys/sequential v0.5.0 h1:OPvI35Lzn9K04PBbCLW0g4LcFAJgHsvXsRyewg5lXtc=
-github.com/moby/sys/sequential v0.5.0/go.mod h1:tH2cOOs5V9MlPiXcQzRC+eEyab644PWKGRYaaV5ZZlo=
 github.com/moby/sys/signal v0.7.0 h1:25RW3d5TnQEoKvRbEKUGay6DCQ46IxAVTT9CUMgmsSI=
 github.com/moby/sys/signal v0.7.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn88Kg8Tg=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587 h1:HfkjXDfhgVaN5rmueG8cL8KKeFNecRCXFhaJ2qZ5SKA=

--- a/launchpad/errors.go
+++ b/launchpad/errors.go
@@ -32,10 +32,6 @@ var errUserNoDockerClient = errorutil.NewUserError(
 	"Unable to get docker cli client. Are you sure Docker is installed?",
 )
 
-var errOldDockerAPIVersion = errorutil.NewUserError(
-	"Launchpad requires your Docker API version to be at least 1.39",
-)
-
 var errNoValidChartVersions = errors.New(
 	"Could not find any valid chart versions",
 )

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -1,18 +1,33 @@
 package docker
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 
-	"github.com/docker/docker/api/types"
+	"go.jetpack.io/launchpad/goutil/errorutil"
 )
 
-func Build(ctx context.Context, path string, opts types.ImageBuildOptions) error {
-	cmd := command(ctx, "docker", "build", path)
-	cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
+type BuildOpts struct {
+	BuildArgs  map[string]*string
+	Dockerfile string
+	Labels     map[string]string
+	Platform   string
+	Tags       []string
+}
+
+func Build(ctx context.Context, path string, opts BuildOpts) error {
+	if err := ensureDocker(); err != nil {
+		return err
+	}
+
+	// TODO implement remote-cache
+	cmd := exec.CommandContext(ctx, "docker", "build", path)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
 	for _, tag := range opts.Tags {
 		cmd.Args = append(cmd.Args, "-t", tag)
 	}
@@ -25,13 +40,36 @@ func Build(ctx context.Context, path string, opts types.ImageBuildOptions) error
 	if opts.Dockerfile != "" {
 		cmd.Args = append(cmd.Args, "-f", filepath.Join(path, opts.Dockerfile))
 	}
-	fmt.Fprintln(os.Stderr, cmd.String())
+	for k, v := range opts.BuildArgs {
+		cmd.Args = append(cmd.Args, "--build-arg", fmt.Sprintf("%s=%s", k, *v))
+	}
+	if os.Getenv("SSH_AUTH_SOCK") != "" {
+		cmd.Args = append(cmd.Args, "--ssh", "default")
+	}
+	fmt.Fprintf(os.Stderr, "Running command: %s\n", cmd.String())
 	return cmd.Run()
 }
 
-func command(ctx context.Context, name string, arg ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, name, arg...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd
+func ensureDocker() error {
+	_, err := exec.LookPath("docker")
+	if err != nil {
+		return errorutil.NewUserError(
+			"docker not found in PATH. Ensure Docker is installed and in your PATH.")
+	}
+	cmd := exec.Command("docker", "version", "--format", "{{.Server.Version}}")
+	out, err := cmd.Output()
+	if err != nil {
+		return errorutil.NewUserError(
+			"failed to get Docker daemon version. Ensure Docker daemon is running.")
+	}
+	version := string(bytes.TrimSpace(out))
+	if version < "1.39" {
+		return errOldDockerAPIVersion
+	}
+	fmt.Fprintf(
+		os.Stderr,
+		"Using Docker daemon version: %s\n",
+		version,
+	)
+	return nil
 }

--- a/pkg/docker/errors.go
+++ b/pkg/docker/errors.go
@@ -1,0 +1,7 @@
+package docker
+
+import "go.jetpack.io/launchpad/goutil/errorutil"
+
+var errOldDockerAPIVersion = errorutil.NewUserError(
+	"Launchpad requires your Docker API version to be at least 1.39",
+)


### PR DESCRIPTION
## Summary

This switches docker build from using golang client to using docker cli. It introduces a few checks (makes sure docker is in path, daemon is running, version is correct). It also adds build args.

## How was it tested?

launchpad up devtools/buildkite/lagobot-app

## Is this change backwards-compatible?
Yes
