### PR TITLE
[Ephemeral Storage] Add request for minimum size of ephemeral storage…

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -2,22 +2,22 @@
   "lockfile_version": "1",
   "packages": {
     "buf@latest": {
-      "last_modified": "2023-06-29T16:20:38Z",
-      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#buf",
+      "last_modified": "2023-08-10T15:58:45Z",
+      "resolved": "github:NixOS/nixpkgs/4d2389b927696ef8da4ef76b03f2d306faf87929#buf",
+      "source": "devbox-search",
+      "version": "1.26.1"
+    },
+    "go@latest": {
+      "last_modified": "2023-08-22T06:04:29Z",
+      "resolved": "github:NixOS/nixpkgs/9d757ec498666cc1dcc6f2be26db4fd3e1e9ab37#go_1_21",
       "source": "devbox-search",
       "version": "1.21.0"
     },
-    "go@latest": {
-      "last_modified": "2023-06-29T16:20:38Z",
-      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#go",
-      "source": "devbox-search",
-      "version": "1.20.5"
-    },
     "golangci-lint@latest": {
-      "last_modified": "2023-06-29T16:20:38Z",
-      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#golangci-lint",
+      "last_modified": "2023-08-22T06:04:29Z",
+      "resolved": "github:NixOS/nixpkgs/9d757ec498666cc1dcc6f2be26db4fd3e1e9ab37#golangci-lint",
       "source": "devbox-search",
-      "version": "1.53.3"
+      "version": "1.54.2"
     }
   }
 }

--- a/padcli/helm/helm.go
+++ b/padcli/helm/helm.go
@@ -146,6 +146,13 @@ func (hvc *ValueComputer) Compute(ctx context.Context) error {
 			websvc.GetInstanceType().Memory(),
 		)
 
+		if *websvc.GetInstanceType() == jetconfig.InstanceType_MEDIUM_PLUS {
+			setNestedFieldPath(
+				hvc.appValues,
+				[]string{"resources", "requests", "ephemeral-storage"},
+				"8Gi",
+			)
+		}
 		hvc.appValues["podPort"] = websvc.GetPort()
 	} else {
 		// This logic will change once we allow multiple services

--- a/padcli/helm/helm.go
+++ b/padcli/helm/helm.go
@@ -150,7 +150,7 @@ func (hvc *ValueComputer) Compute(ctx context.Context) error {
 			setNestedFieldPath(
 				hvc.appValues,
 				[]string{"resources", "requests", "ephemeral-storage"},
-				"8Gi",
+				"10Gi",
 			)
 		}
 		hvc.appValues["podPort"] = websvc.GetPort()


### PR DESCRIPTION
… for Medium+ instances

## Summary

Medium-Plus instance projects may likely require more disk space. So, make a minimum request of 8GB.

Ping internally for additional motivations.

## How was it tested?

Did not test.
Tried compiling (but fails on x86-darwin for nix reasons; looking into it)

## Is this change backwards-compatible?

yes

