### PR TITLE
Revert "[Ephemeral Storage] Add request for minimum size of ephemeral…

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -2,22 +2,22 @@
   "lockfile_version": "1",
   "packages": {
     "buf@latest": {
-      "last_modified": "2023-08-10T15:58:45Z",
-      "resolved": "github:NixOS/nixpkgs/4d2389b927696ef8da4ef76b03f2d306faf87929#buf",
-      "source": "devbox-search",
-      "version": "1.26.1"
-    },
-    "go@latest": {
-      "last_modified": "2023-08-22T06:04:29Z",
-      "resolved": "github:NixOS/nixpkgs/9d757ec498666cc1dcc6f2be26db4fd3e1e9ab37#go_1_21",
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#buf",
       "source": "devbox-search",
       "version": "1.21.0"
     },
-    "golangci-lint@latest": {
-      "last_modified": "2023-08-22T06:04:29Z",
-      "resolved": "github:NixOS/nixpkgs/9d757ec498666cc1dcc6f2be26db4fd3e1e9ab37#golangci-lint",
+    "go@latest": {
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#go",
       "source": "devbox-search",
-      "version": "1.54.2"
+      "version": "1.20.5"
+    },
+    "golangci-lint@latest": {
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#golangci-lint",
+      "source": "devbox-search",
+      "version": "1.53.3"
     }
   }
 }

--- a/padcli/helm/helm.go
+++ b/padcli/helm/helm.go
@@ -146,13 +146,6 @@ func (hvc *ValueComputer) Compute(ctx context.Context) error {
 			websvc.GetInstanceType().Memory(),
 		)
 
-		if *websvc.GetInstanceType() == jetconfig.InstanceType_MEDIUM_PLUS {
-			setNestedFieldPath(
-				hvc.appValues,
-				[]string{"resources", "requests", "ephemeral-storage"},
-				"10Gi",
-			)
-		}
 		hvc.appValues["podPort"] = websvc.GetPort()
 	} else {
 		// This logic will change once we allow multiple services


### PR DESCRIPTION
… storage… (#56)"

This reverts commit 1c7247e6fa176e36d7b18866cf4ca907556b0618.

## Summary

This PR reverts the change, since AFAIK Greg couldn't successfully deploy with this change. He found another workaround for his service.

## How was it tested?

compiles.
Did `git revert <commit hash>`

## Is this change backwards-compatible?

yes